### PR TITLE
Added Hostname

### DIFF
--- a/shared/src/main/scala/com/comcast/ip4s/Hostname.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Hostname.scala
@@ -67,7 +67,7 @@ object Hostname {
   }
 
   private val Pattern =
-    """[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}?[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}?[a-zA-Z0-9])?)*""".r
+    """[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*""".r
 
   /** Constructs a `Hostname` from a string. */
   def apply(value: String): Option[Hostname] = value.size match {

--- a/shared/src/main/scala/com/comcast/ip4s/Hostname.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Hostname.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+
+import scala.util.hashing.MurmurHash3
+
+/**
+  * RFC1123 compliant hostname.
+  *
+  * A hostname contains one or more labels, where each label consists of letters A-Z, a-z, digits 0-9, or a dash.
+  * A label may not start or end in a dash and may not exceed 63 characters in length. Labels are separated by
+  * periods and the overall hostname must not exceed 253 characters in length.
+  */
+final class Hostname private (private val head: Hostname.Label,
+                              private val tail: List[Hostname.Label],
+                              override val toString: String)
+    extends Ordered[Hostname] {
+
+  /** Gets the labels of this hostname. */
+  def labels: (Hostname.Label, List[Hostname.Label]) = (head, tail)
+
+  /** Gets the labels of this hostname as a list, guaranteed to have at least one element. */
+  def labelsList: List[Hostname.Label] = head :: tail
+
+  def compare(that: Hostname): Int = toString.compare(that.toString)
+  override def hashCode: Int = MurmurHash3.stringHash(toString, "Hostname".hashCode)
+  override def equals(other: Any): Boolean = other match {
+    case that: Hostname => toString == that.toString
+    case _              => false
+  }
+}
+
+object Hostname {
+
+  /**
+    * Label component of a hostname.
+    *
+    * A label consists of letters A-Z, a-z, digits 0-9, or a dash. A label may not start or end in a
+    * dash and may not exceed 63 characters in length.
+    */
+  final class Label private[Hostname] (val value: String) extends Product with Serializable with Ordered[Label] {
+    def compare(that: Label): Int = value.compare(that.value)
+    override def toString: String = value
+    override def hashCode: Int = MurmurHash3.productHash(this, productPrefix.hashCode)
+    override def equals(other: Any): Boolean = other match {
+      case that: Label => value == that.value
+      case _           => false
+    }
+    override def canEqual(other: Any): Boolean = other.isInstanceOf[Label]
+    override def productArity: Int = 1
+    override def productElement(n: Int): Any =
+      if (n == 0) value else throw new IndexOutOfBoundsException
+  }
+
+  private val Pattern =
+    """[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}?[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}?[a-zA-Z0-9])?)*""".r
+
+  /** Constructs a `Hostname` from a string. */
+  def apply(value: String): Option[Hostname] = value.size match {
+    case 0            => None
+    case i if i > 253 => None
+    case _ =>
+      value match {
+        case Pattern(_*) =>
+          val labels = value
+            .split('.')
+            .iterator
+            .map(new Label(_))
+            .toList
+          Some(new Hostname(labels.head, labels.tail, value))
+        case _ => None
+      }
+  }
+}

--- a/shared/src/test/scala/com/comcast/ip4s/Arbitraries.scala
+++ b/shared/src/test/scala/com/comcast/ip4s/Arbitraries.scala
@@ -94,4 +94,20 @@ object Arbitraries {
 
   implicit def multicastSocketAddressArbitrary[A <: IpAddress](implicit arbJoin: Arbitrary[MulticastJoin[A]], arbPort: Arbitrary[Port]): Arbitrary[MulticastSocketAddress[MulticastJoin, A]] =
     Arbitrary(multicastSocketAddressGenerator(arbJoin.arbitrary, arbPort.arbitrary))
+
+  val hostnameGenerator: Gen[Hostname] = {
+    val genLabel: Gen[String] = for {
+      first <- Gen.alphaNumChar
+      middleLen <- Gen.chooseNum(0, 61)
+      middle <- Gen.listOfN(middleLen, Gen.oneOf(Gen.alphaNumChar, Gen.const('-'))).map(_.mkString)
+      last <- if (middleLen > 0) Gen.alphaNumChar.map(Some(_)) else Gen.option(Gen.alphaNumChar)
+    } yield first.toString + middle + last.fold("")(_.toString)
+    for {
+      numLabels <- Gen.chooseNum(1, 5)
+      labels <- Gen.listOfN(numLabels, genLabel)
+      if labels.foldLeft(0)(_ + _.size) < (253 - numLabels)
+    } yield Hostname(labels.mkString(".")).get
+  }
+
+  implicit val hostnameArbitrary: Arbitrary[Hostname] = Arbitrary(hostnameGenerator)
 }

--- a/shared/src/test/scala/com/comcast/ip4s/Arbitraries.scala
+++ b/shared/src/test/scala/com/comcast/ip4s/Arbitraries.scala
@@ -105,7 +105,7 @@ object Arbitraries {
     for {
       numLabels <- Gen.chooseNum(1, 5)
       labels <- Gen.listOfN(numLabels, genLabel)
-      if labels.foldLeft(0)(_ + _.size) < (253 - numLabels)
+      if labels.foldLeft(0)(_ + _.size) < (253 - (numLabels - 1))
     } yield Hostname(labels.mkString(".")).get
   }
 

--- a/shared/src/test/scala/com/comcast/ip4s/BaseTestSuite.scala
+++ b/shared/src/test/scala/com/comcast/ip4s/BaseTestSuite.scala
@@ -21,5 +21,5 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 abstract class BaseTestSuite extends WordSpec with GeneratorDrivenPropertyChecks with Matchers {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    PropertyCheckConfiguration(minSuccessful = 10000)
+    PropertyCheckConfiguration(minSuccessful = 5000)
 }

--- a/shared/src/test/scala/com/comcast/ip4s/HostnameTest.scala
+++ b/shared/src/test/scala/com/comcast/ip4s/HostnameTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+
+import Arbitraries._
+
+class HostnameTest extends BaseTestSuite {
+
+  "Hostname" should {
+    "roundtrip through string" in {
+      forAll { (h: Hostname) =>
+        Hostname(h.toString) shouldBe Some(h)
+      }
+    }
+
+    "allow access to labels" in {
+      forAll { (h: Hostname) =>
+        Hostname(h.labelsList.mkString(".")) shouldBe Some(h)
+        val t = h.labels
+        Hostname((t._1 :: t._2).mkString(".")) shouldBe Some(h)
+      }
+    }
+
+    "require overall length be less than 254 chars" in {
+      forAll { (h: Hostname) =>
+        val hstr = h.toString 
+        val h2 = hstr + "." + hstr
+        val expected = if (h2.length > 253) None else Some(Hostname(h2).get)
+        Hostname(h2) shouldBe expected
+      }
+    }
+
+    "require labels be less than 64 chars" in {
+      forAll { (h: Hostname) =>
+        val hstr = h.toString
+        val suffix = new String(Array.fill(63)(hstr.last))
+        val tooLong = hstr + suffix
+        Hostname(tooLong) shouldBe None
+      }
+    }
+    
+    "disallow labels that end in a dash" in {
+      forAll { (h: Hostname) =>
+        val hstr = h.toString
+        val disallowed = hstr + "-"
+        Hostname(disallowed) shouldBe None
+      }
+    }
+
+    "disallow labels that start with a dash" in {
+      forAll { (h: Hostname) =>
+        val hstr = h.toString
+        val disallowed = "-" + hstr
+        Hostname(disallowed) shouldBe None
+      }
+    }
+  }
+}


### PR DESCRIPTION
Partial fix for #1.

What remains:
 - Decide if we should support IDNs/unicode hostnames. See #1 for details on this.
 - Decide on how to support resolving a `HostName` via DNS to an `IpAddress`(es) -- either via a cats-effect add-on module or by adding a cats-effect dependency directly to the core project. In either case, we should decide on how to express the blocking call to `InetAddress.get(All)ByName` -- e.g., via `https://github.com/ChristopherDavenport/linebacker` perhaps. I'm currently leaning towards adding the cats-effect dependency as it's already needed by other foundational libraries like fs2, doobie, https, and monix.

