### PR TITLE
Multicast and SourceSpecificMulticast should be considered equal if they reference same ip

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform).
   settings(
     name := "ip4s",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-effect" % "1.0.0-RC2-93ac33d",
+      "org.typelevel" %%% "cats-effect" % "0.10",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
       "org.scalacheck" %%% "scalacheck" % "1.14.0" % "test"
     ),

--- a/shared/src/main/scala/com/comcast/ip4s/Multicast.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Multicast.scala
@@ -30,16 +30,14 @@ sealed trait Multicast[+A <: IpAddress] extends Product with Serializable {
 
 object Multicast {
   private case class DefaultMulticast[+A <: IpAddress](address: A) extends Multicast[A] {
-    override def equals(that: Any): Boolean = that match {
-      case that: Multicast[A] => address == that.address
-    }
-    override def hashCode: Int = address.hashCode
     override def toString: String = address.toString
   }
 
   /** Constructs a multicast IP address. Returns `None` is the supplied address is not in the valid multicast range. */
   def apply[A <: IpAddress](address: A): Option[Multicast[A]] =
-    if (address.isMulticast) Some(new DefaultMulticast(address)) else None
+    if (address.isSourceSpecificMulticast) Some(SourceSpecificMulticast.unsafeCreate(address))
+    else if (address.isMulticast) Some(DefaultMulticast(address))
+    else None
 
   implicit def ordering[A <: IpAddress]: Ordering[Multicast[A]] = Ordering.by(_.address)
 
@@ -60,16 +58,15 @@ sealed trait SourceSpecificMulticast[+A <: IpAddress] extends Multicast[A] {
 
 object SourceSpecificMulticast {
   private case class DefaultSourceSpecificMulticast[+A <: IpAddress](address: A) extends SourceSpecificMulticast[A] {
-    override def equals(that: Any): Boolean = that match {
-      case that: Multicast[A] => address == that.address
-    }
-    override def hashCode: Int = address.hashCode
     override def toString: String = address.toString
   }
 
   /** Constructs a source specific multicast IP address. Returns `None` is the supplied address is not in the valid source specific multicast range. */
   def apply[A <: IpAddress](address: A): Option[SourceSpecificMulticast[A]] =
     if (address.isSourceSpecificMulticast) Some(new DefaultSourceSpecificMulticast(address)) else None
+
+  private[ip4s] def unsafeCreate[A <: IpAddress](address: A): SourceSpecificMulticast[A] =
+    DefaultSourceSpecificMulticast(address)
 
   implicit def ordering[A <: IpAddress]: Ordering[SourceSpecificMulticast[A]] =
     new Ordering[SourceSpecificMulticast[A]] {

--- a/shared/src/main/scala/com/comcast/ip4s/Multicast.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Multicast.scala
@@ -30,12 +30,16 @@ sealed trait Multicast[+A <: IpAddress] extends Product with Serializable {
 
 object Multicast {
   private case class DefaultMulticast[+A <: IpAddress](address: A) extends Multicast[A] {
+    override def equals(that: Any): Boolean = that match {
+      case that: Multicast[A] => address == that.address
+    }
+    override def hashCode: Int = address.hashCode
     override def toString: String = address.toString
   }
 
   /** Constructs a multicast IP address. Returns `None` is the supplied address is not in the valid multicast range. */
   def apply[A <: IpAddress](address: A): Option[Multicast[A]] =
-    if (address.isMulticast) Some(DefaultMulticast(address)) else None
+    if (address.isMulticast) Some(new DefaultMulticast(address)) else None
 
   implicit def ordering[A <: IpAddress]: Ordering[Multicast[A]] = Ordering.by(_.address)
 
@@ -50,18 +54,20 @@ object Multicast {
   * An instance of `SourceSpecificMulticast` is typically created by either calling `Multicast.apply`
   * or by using the `asSourceSpecificMulticast` method on `IpAddress`.
   */
-sealed trait SourceSpecificMulticast[+A <: IpAddress] extends Multicast[A] {
-  override def toString: String = address.toString
-}
+sealed trait SourceSpecificMulticast[+A <: IpAddress] extends Multicast[A]
 
 object SourceSpecificMulticast {
   private case class DefaultSourceSpecificMulticast[+A <: IpAddress](address: A) extends SourceSpecificMulticast[A] {
+    override def equals(that: Any): Boolean = that match {
+      case that: Multicast[A] => address == that.address
+    }
+    override def hashCode: Int = address.hashCode
     override def toString: String = address.toString
   }
 
   /** Constructs a source specific multicast IP address. Returns `None` is the supplied address is not in the valid source specific multicast range. */
   def apply[A <: IpAddress](address: A): Option[SourceSpecificMulticast[A]] =
-    if (address.isSourceSpecificMulticast) Some(DefaultSourceSpecificMulticast(address)) else None
+    if (address.isSourceSpecificMulticast) Some(new DefaultSourceSpecificMulticast(address)) else None
 
   implicit def ordering[A <: IpAddress]: Ordering[SourceSpecificMulticast[A]] =
     new Ordering[SourceSpecificMulticast[A]] {

--- a/shared/src/main/scala/com/comcast/ip4s/Multicast.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Multicast.scala
@@ -54,7 +54,9 @@ object Multicast {
   * An instance of `SourceSpecificMulticast` is typically created by either calling `Multicast.apply`
   * or by using the `asSourceSpecificMulticast` method on `IpAddress`.
   */
-sealed trait SourceSpecificMulticast[+A <: IpAddress] extends Multicast[A]
+sealed trait SourceSpecificMulticast[+A <: IpAddress] extends Multicast[A] {
+  override def toString: String = address.toString
+}
 
 object SourceSpecificMulticast {
   private case class DefaultSourceSpecificMulticast[+A <: IpAddress](address: A) extends SourceSpecificMulticast[A] {

--- a/shared/src/test/scala/com/comcast/ip4s/IDNTest.scala
+++ b/shared/src/test/scala/com/comcast/ip4s/IDNTest.scala
@@ -24,7 +24,7 @@ class IDNTest extends BaseTestSuite {
     "support any hostname" in {
       forAll { (h: Hostname) =>
         val i = IDN.fromHostname(h)
-        val representable = h.labels.forall(l => !l.toString.startsWith("xn--"))
+        val representable = h.labels.forall(l => !l.toString.toLowerCase.startsWith("xn--"))
         if (representable) {
           i.hostname shouldBe h
           IDN(h.toString) shouldBe Some(i)

--- a/shared/src/test/scala/com/comcast/ip4s/MulticastTest.scala
+++ b/shared/src/test/scala/com/comcast/ip4s/MulticastTest.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+
+import Arbitraries._
+
+class MulticastTest extends BaseTestSuite {
+
+  "Multicast" should {
+    "support equality" in {
+      forAll { (mip: Multicast[IpAddress]) =>
+        mip.address.asMulticast shouldBe Some(mip)
+        mip.address.asSourceSpecificMulticast.foreach(_ shouldBe mip)
+        mip.address.asSourceSpecificMulticast.foreach(mip shouldBe _)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Downgraded cats-effect dependency so we can release a fix soon.