### PR TITLE
Split into core and cats modules

### DIFF
--- a/cats/jvm/src/main/scala/com/comcast/ip4s/HostnameResolver.scala
+++ b/cats/jvm/src/main/scala/com/comcast/ip4s/HostnameResolver.scala
@@ -15,13 +15,16 @@
  */
 
 package com.comcast.ip4s
+package interop.cats
 
-import cats.data.NonEmptyList
-import cats.effect.Sync
 import java.net.{InetAddress, UnknownHostException}
+
 import scala.language.higherKinds
 
-private[ip4s] trait HostnamePlatform {
+import _root_.cats.data.NonEmptyList
+import _root_.cats.effect.Sync
+
+object HostnameResolver {
 
   /**
     * Resolves this hostname to an ip address using the platform DNS resolver.
@@ -31,10 +34,10 @@ private[ip4s] trait HostnamePlatform {
     * Resolution happens synchronously when the returned task is evaluated
     * so consider shifting the returned task to a blocking execution context.
     */
-  def resolve[F[_]: Sync]: F[Option[IpAddress]] =
+  def resolve[F[_]: Sync](hostname: Hostname): F[Option[IpAddress]] =
     Sync[F].delay {
       try {
-        val addr = InetAddress.getByName(toString)
+        val addr = InetAddress.getByName(hostname.toString)
         IpAddress.fromBytes(addr.getAddress)
       } catch {
         case _: UnknownHostException => None
@@ -49,10 +52,10 @@ private[ip4s] trait HostnamePlatform {
     * Resolution happens synchronously when the returned task is evaluated
     * so consider shifting the returned task to a blocking execution context.
     */
-  def resolveAll[F[_]: Sync]: F[Option[NonEmptyList[IpAddress]]] =
+  def resolveAll[F[_]: Sync](hostname: Hostname): F[Option[NonEmptyList[IpAddress]]] =
     Sync[F].delay {
       try {
-        val addrs = InetAddress.getAllByName(toString)
+        val addrs = InetAddress.getAllByName(hostname.toString)
         NonEmptyList.fromList(addrs.toList.flatMap(addr => IpAddress.fromBytes(addr.getAddress)))
       } catch {
         case _: UnknownHostException => None

--- a/cats/jvm/src/main/tut/guide.md
+++ b/cats/jvm/src/main/tut/guide.md
@@ -240,12 +240,13 @@ On the JVM, hostnames can be resolved to IP addresses via `resolve` and `resolve
 
 ```tut
 import cats.effect.IO
+import com.comcast.ip4s.interop.cats._
 
 val home = host"localhost"
-val homeIp = home.resolve[IO]
+val homeIp = HostnameResolver.resolve[IO](home)
 homeIp.unsafeRunSync
 
-val homeIps = home.resolveAll[IO]
+val homeIps = HostnameResolver.resolveAll[IO](home)
 homeIps.unsafeRunSync
 ```
 

--- a/cats/jvm/src/test/scala/com/comcast/ip4s/HostnameJvmTest.scala
+++ b/cats/jvm/src/test/scala/com/comcast/ip4s/HostnameJvmTest.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+package interop.cats
+
+import _root_.cats.effect.IO
+
+class HostnameJvmTest extends BaseTestSuite {
+
+  "Hostname" should {
+    "support ip resolution" in {
+      val localhost = Hostname("localhost").get
+      val ip = HostnameResolver.resolve[IO](localhost).unsafeRunSync
+      ip shouldBe 'defined
+      val allIps = HostnameResolver.resolveAll[IO](localhost).unsafeRunSync
+      allIps.get.toList should contain(ip.get)
+    }
+  }
+}

--- a/cats/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
+++ b/cats/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+package interop.cats
+
+import _root_.cats.{Eq, Order, Show}
+
+trait CidrInstances {
+  implicit def CidrEq[A <: IpAddress]: Eq[Cidr[A]] = Eq.fromUniversalEquals[Cidr[A]]
+  implicit def CidrOrder[A <: IpAddress]: Order[Cidr[A]] = Order.fromOrdering(Cidr.ordering[A])
+  implicit def CidrShow[A <: IpAddress]: Show[Cidr[A]] = Show.fromToString[Cidr[A]]
+}

--- a/cats/shared/src/main/scala/com/comcast/ip4s/Hostname.scala
+++ b/cats/shared/src/main/scala/com/comcast/ip4s/Hostname.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+package interop.cats
+
+import _root_.cats.{Eq, Order, Show}
+
+trait HostnameInstances {
+  implicit val HostnameEq: Eq[Hostname] = Eq.fromUniversalEquals[Hostname]
+  implicit val HostnameOrder: Order[Hostname] = Order.fromComparable[Hostname]
+  implicit val HostnameShow: Show[Hostname] = Show.fromToString[Hostname]
+}

--- a/cats/shared/src/main/scala/com/comcast/ip4s/IDN.scala
+++ b/cats/shared/src/main/scala/com/comcast/ip4s/IDN.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+package interop.cats
+
+import _root_.cats.{Eq, Order, Show}
+
+trait IDNInstances {
+  implicit val IDNEq: Eq[IDN] = Eq.fromUniversalEquals[IDN]
+  implicit val IDNOrder: Order[IDN] = Order.fromComparable[IDN]
+  implicit val IDNShow: Show[IDN] = Show.fromToString[IDN]
+}

--- a/cats/shared/src/main/scala/com/comcast/ip4s/Implicits.scala
+++ b/cats/shared/src/main/scala/com/comcast/ip4s/Implicits.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s.interop.cats
+
+object implicits
+    extends CidrInstances
+    with HostnameInstances
+    with IDNInstances
+    with IpAddressInstances
+    with MulticastInstances
+    with MulticastJoinInstances
+    with MulticastSocketAddressInstances
+    with PortInstances
+    with SocketAddressInstances

--- a/cats/shared/src/main/scala/com/comcast/ip4s/IpAddress.scala
+++ b/cats/shared/src/main/scala/com/comcast/ip4s/IpAddress.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+package interop.cats
+
+import _root_.cats.{Eq, Order, Show}
+
+trait IpAddressInstances {
+  implicit def IpAddressEq[A <: IpAddress]: Eq[A] = Eq.fromUniversalEquals[A]
+  implicit def IPAddressOrder[A <: IpAddress]: Order[A] = Order.fromOrdering(IpAddress.ordering[A])
+  implicit def IPAddressShow[A <: IpAddress]: Show[A] = Show.fromToString[A]
+}

--- a/cats/shared/src/main/scala/com/comcast/ip4s/Multicast.scala
+++ b/cats/shared/src/main/scala/com/comcast/ip4s/Multicast.scala
@@ -15,5 +15,12 @@
  */
 
 package com.comcast.ip4s
+package interop.cats
 
-private[ip4s] trait HostnamePlatform
+import _root_.cats.{Eq, Order, Show}
+
+trait MulticastInstances {
+  implicit def MulticastEq[A <: IpAddress]: Eq[Multicast[A]] = Eq.fromUniversalEquals[Multicast[A]]
+  implicit def MulticastOrder[A <: IpAddress]: Order[Multicast[A]] = Order.fromOrdering(Multicast.ordering[A])
+  implicit def MulticastShow[A <: IpAddress]: Show[Multicast[A]] = Show.fromToString[Multicast[A]]
+}

--- a/cats/shared/src/main/scala/com/comcast/ip4s/MulticastJoin.scala
+++ b/cats/shared/src/main/scala/com/comcast/ip4s/MulticastJoin.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+package interop.cats
+
+import _root_.cats.{Eq, Order, Show}
+
+trait MulticastJoinInstances {
+  implicit def MulticastJoinEq[J[x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]: Eq[J[A]] =
+    Eq.fromUniversalEquals[J[A]]
+  implicit def MulticastJoinOrder[J[x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]: Order[J[A]] =
+    Order.fromOrdering(MulticastJoin.ordering[J, A])
+  implicit def MulticastJoinShow[J[x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]: Show[J[A]] =
+    Show.fromToString[J[A]]
+}

--- a/cats/shared/src/main/scala/com/comcast/ip4s/MulticastSocketAddress.scala
+++ b/cats/shared/src/main/scala/com/comcast/ip4s/MulticastSocketAddress.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+package interop.cats
+
+import _root_.cats.{Eq, Order, Show}
+
+trait MulticastSocketAddressInstances {
+  implicit def MulticastSocketAddressEq[J[+x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]
+    : Eq[MulticastSocketAddress[J, A]] =
+    Eq.fromUniversalEquals[MulticastSocketAddress[J, A]]
+  implicit def MulticastSocketAddressOrder[J[+x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]
+    : Order[MulticastSocketAddress[J, A]] =
+    Order.fromOrdering(MulticastSocketAddress.ordering[J, A])
+  implicit def MulticastSocketAddressShow[J[+x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]
+    : Show[MulticastSocketAddress[J, A]] =
+    Show.fromToString[MulticastSocketAddress[J, A]]
+}

--- a/cats/shared/src/main/scala/com/comcast/ip4s/Port.scala
+++ b/cats/shared/src/main/scala/com/comcast/ip4s/Port.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+package interop.cats
+
+import _root_.cats.{Eq, Order, Show}
+
+trait PortInstances {
+  implicit val PortEq: Eq[Port] = Eq.fromUniversalEquals[Port]
+  implicit val PortOrder: Order[Port] = Order.fromComparable[Port]
+  implicit val PortShow: Show[Port] = Show.fromToString[Port]
+}

--- a/cats/shared/src/main/scala/com/comcast/ip4s/SocketAddress.scala
+++ b/cats/shared/src/main/scala/com/comcast/ip4s/SocketAddress.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+package interop.cats
+
+import _root_.cats.{Eq, Order, Show}
+
+trait SocketAddressInstances {
+  implicit def SocketAddressEq[A <: IpAddress]: Eq[SocketAddress[A]] = Eq.fromUniversalEquals[SocketAddress[A]]
+  implicit def SocketAddressOrder[A <: IpAddress]: Order[SocketAddress[A]] =
+    Order.fromOrdering(SocketAddress.ordering[A])
+  implicit def SocketAddressShow[A <: IpAddress]: Show[SocketAddress[A]] = Show.fromToString[SocketAddress[A]]
+}

--- a/cats/shared/src/test/scala/com/comcast/ip4s/BaseTestSuite.scala
+++ b/cats/shared/src/test/scala/com/comcast/ip4s/BaseTestSuite.scala
@@ -15,18 +15,12 @@
  */
 
 package com.comcast.ip4s
+package interop.cats
 
-import cats.effect.IO
+import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
-class HostnameJvmTest extends BaseTestSuite {
-
-  "Hostname" should {
-    "support ip resolution" in {
-      val localhost = Hostname("localhost").get
-      val ip = localhost.resolve[IO].unsafeRunSync
-      ip shouldBe 'defined
-      val allIps = localhost.resolveAll[IO].unsafeRunSync
-      allIps.get.toList should contain(ip.get)
-    }
-  }
+abstract class BaseTestSuite extends WordSpec with GeneratorDrivenPropertyChecks with Matchers {
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(minSuccessful = 5000)
 }

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -320,13 +320,13 @@ scala> val home = Hostname("localhost")
 home: Option[com.comcast.ip4s.Hostname] = Some(localhost)
 
 scala> val ls = home.map(_.labels)
-ls: Option[cats.data.NonEmptyList[com.comcast.ip4s.Hostname.Label]] = Some(NonEmptyList(localhost))
+ls: Option[List[com.comcast.ip4s.Hostname.Label]] = Some(List(localhost))
 
 scala> val comcast = host"comcast.com"
 comcast: com.comcast.ip4s.Hostname = comcast.com
 
 scala> val cs = comcast.labels
-cs: cats.data.NonEmptyList[com.comcast.ip4s.Hostname.Label] = NonEmptyList(comcast, com)
+cs: List[com.comcast.ip4s.Hostname.Label] = List(comcast, com)
 ```
 
 On the JVM, hostnames can be resolved to IP addresses via `resolve` and `resolveAll`:
@@ -335,17 +335,20 @@ On the JVM, hostnames can be resolved to IP addresses via `resolve` and `resolve
 scala> import cats.effect.IO
 import cats.effect.IO
 
+scala> import com.comcast.ip4s.interop.cats._
+import com.comcast.ip4s.interop.cats._
+
 scala> val home = host"localhost"
 home: com.comcast.ip4s.Hostname = localhost
 
-scala> val homeIp = home.resolve[IO]
-homeIp: cats.effect.IO[Option[com.comcast.ip4s.IpAddress]] = IO$2061525123
+scala> val homeIp = HostnameResolver.resolve[IO](home)
+homeIp: cats.effect.IO[Option[com.comcast.ip4s.IpAddress]] = IO$823547879
 
 scala> homeIp.unsafeRunSync
 res0: Option[com.comcast.ip4s.IpAddress] = Some(127.0.0.1)
 
-scala> val homeIps = home.resolveAll[IO]
-homeIps: cats.effect.IO[Option[cats.data.NonEmptyList[com.comcast.ip4s.IpAddress]]] = IO$458869682
+scala> val homeIps = HostnameResolver.resolveAll[IO](home)
+homeIps: cats.effect.IO[Option[cats.data.NonEmptyList[com.comcast.ip4s.IpAddress]]] = IO$986520546
 
 scala> homeIps.unsafeRunSync
 res1: Option[cats.data.NonEmptyList[com.comcast.ip4s.IpAddress]] = Some(NonEmptyList(127.0.0.1, ::1))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.0

--- a/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
@@ -16,7 +16,6 @@
 
 package com.comcast.ip4s
 
-import cats.{Eq, Order, Show}
 import scala.math.Ordering.Implicits._
 import scala.util.Try
 import scala.util.hashing.MurmurHash3
@@ -147,10 +146,6 @@ object Cidr {
     }
 
   implicit def ordering[A <: IpAddress]: Ordering[Cidr[A]] = Ordering.by(x => (x.address, x.prefixBits))
-
-  implicit def eq[A <: IpAddress]: Eq[Cidr[A]] = Eq.fromUniversalEquals[Cidr[A]]
-  implicit def order[A <: IpAddress]: Order[Cidr[A]] = Order.fromOrdering(ordering[A])
-  implicit def show[A <: IpAddress]: Show[Cidr[A]] = Show.fromToString[Cidr[A]]
 
   def unapply[A <: IpAddress](c: Cidr[A]): Option[(A, Int)] = Some((c.address, c.prefixBits))
 }

--- a/shared/src/main/scala/com/comcast/ip4s/Hostname.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Hostname.scala
@@ -16,8 +16,6 @@
 
 package com.comcast.ip4s
 
-import cats.{Eq, Order, Show}
-import cats.data.NonEmptyList
 import scala.util.hashing.MurmurHash3
 
 /**
@@ -27,9 +25,8 @@ import scala.util.hashing.MurmurHash3
   * A label may not start or end in a dash and may not exceed 63 characters in length. Labels are separated by
   * periods and the overall hostname must not exceed 253 characters in length.
   */
-final class Hostname private (val labels: NonEmptyList[Hostname.Label], override val toString: String)
-    extends HostnamePlatform
-    with Ordered[Hostname] {
+final class Hostname private (val labels: List[Hostname.Label], override val toString: String)
+    extends Ordered[Hostname] {
 
   /** Converts this hostname to lower case. */
   def normalized: Hostname =
@@ -75,12 +72,8 @@ object Hostname {
             .iterator
             .map(new Label(_))
             .toList
-          NonEmptyList.fromList(labels).map(new Hostname(_, value))
+          if (labels.isEmpty) None else Option(new Hostname(labels, value))
         case _ => None
       }
   }
-
-  implicit val eq: Eq[Hostname] = Eq.fromUniversalEquals[Hostname]
-  implicit val order: Order[Hostname] = Order.fromComparable[Hostname]
-  implicit val show: Show[Hostname] = Show.fromToString[Hostname]
 }

--- a/shared/src/main/scala/com/comcast/ip4s/IpAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/IpAddress.scala
@@ -16,7 +16,6 @@
 
 package com.comcast.ip4s
 
-import cats.{Eq, Order, Show}
 import scala.math.Ordering.Implicits._
 
 /**
@@ -132,10 +131,6 @@ object IpAddress {
           }
       }
   }
-
-  implicit def eq[A <: IpAddress]: Eq[A] = Eq.fromUniversalEquals[A]
-  implicit def order[A <: IpAddress]: Order[A] = Order.fromOrdering(ordering[A])
-  implicit def show[A <: IpAddress]: Show[A] = Show.fromToString[A]
 }
 
 /** Representation of an IPv4 address that works on both the JVM and Scala.js. */

--- a/shared/src/main/scala/com/comcast/ip4s/Multicast.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Multicast.scala
@@ -16,8 +16,6 @@
 
 package com.comcast.ip4s
 
-import cats.{Eq, Order, Show}
-
 /**
   * Witness that the wrapped address of type `A` is a multicast address.
   *
@@ -40,10 +38,6 @@ object Multicast {
     else None
 
   implicit def ordering[A <: IpAddress]: Ordering[Multicast[A]] = Ordering.by(_.address)
-
-  implicit def eq[A <: IpAddress]: Eq[Multicast[A]] = Eq.fromUniversalEquals[Multicast[A]]
-  implicit def order[A <: IpAddress]: Order[Multicast[A]] = Order.fromOrdering(ordering[A])
-  implicit def show[A <: IpAddress]: Show[Multicast[A]] = Show.fromToString[Multicast[A]]
 }
 
 /**

--- a/shared/src/main/scala/com/comcast/ip4s/MulticastJoin.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/MulticastJoin.scala
@@ -16,7 +16,6 @@
 
 package com.comcast.ip4s
 
-import cats.{Eq, Order, Show}
 import scala.language.higherKinds
 
 /**
@@ -94,13 +93,6 @@ object MulticastJoin {
 
   implicit def ordering[J[x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]: Ordering[J[A]] =
     Ordering.by(_.sourceAndGroup)
-
-  implicit def eq[J[x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]: Eq[J[A]] =
-    Eq.fromUniversalEquals[J[A]]
-  implicit def order[J[x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]: Order[J[A]] =
-    Order.fromOrdering(ordering[J, A])
-  implicit def show[J[x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]: Show[J[A]] =
-    Show.fromToString[J[A]]
 }
 
 /** Multicast join to a group without a source filter. */

--- a/shared/src/main/scala/com/comcast/ip4s/MulticastSocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/MulticastSocketAddress.scala
@@ -16,7 +16,6 @@
 
 package com.comcast.ip4s
 
-import cats.{Eq, Order, Show}
 import scala.language.higherKinds
 
 /**
@@ -100,11 +99,4 @@ object MulticastSocketAddress {
 
   implicit def ordering[J[+x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]
     : Ordering[MulticastSocketAddress[J, A]] = Ordering.by(x => (x.join, x.port))
-
-  implicit def eq[J[+x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]: Eq[MulticastSocketAddress[J, A]] =
-    Eq.fromUniversalEquals[MulticastSocketAddress[J, A]]
-  implicit def order[J[+x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]: Order[MulticastSocketAddress[J, A]] =
-    Order.fromOrdering(ordering[J, A])
-  implicit def show[J[+x <: IpAddress] <: MulticastJoin[x], A <: IpAddress]: Show[MulticastSocketAddress[J, A]] =
-    Show.fromToString[MulticastSocketAddress[J, A]]
 }

--- a/shared/src/main/scala/com/comcast/ip4s/Port.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Port.scala
@@ -16,7 +16,6 @@
 
 package com.comcast.ip4s
 
-import cats.{Eq, Order, Show}
 import scala.util.Try
 import scala.util.hashing.MurmurHash3
 
@@ -47,8 +46,4 @@ object Port {
     Try(value.toInt).toOption.flatMap(apply)
 
   def unapply(p: Port): Option[Int] = Some(p.value)
-
-  implicit val eq: Eq[Port] = Eq.fromUniversalEquals[Port]
-  implicit val order: Order[Port] = Order.fromComparable[Port]
-  implicit val show: Show[Port] = Show.fromToString[Port]
 }

--- a/shared/src/main/scala/com/comcast/ip4s/SocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/SocketAddress.scala
@@ -16,8 +16,6 @@
 
 package com.comcast.ip4s
 
-import cats.{Eq, Order, Show}
-
 /**
   * An IP address of the specified type and a port number. Used to describe the source or destination of a socket.
   */
@@ -54,8 +52,4 @@ object SocketAddress {
     }
 
   implicit def ordering[A <: IpAddress]: Ordering[SocketAddress[A]] = Ordering.by(x => (x.ip, x.port))
-
-  implicit def eq[A <: IpAddress]: Eq[SocketAddress[A]] = Eq.fromUniversalEquals[SocketAddress[A]]
-  implicit def order[A <: IpAddress]: Order[SocketAddress[A]] = Order.fromOrdering(ordering[A])
-  implicit def show[A <: IpAddress]: Show[SocketAddress[A]] = Show.fromToString[SocketAddress[A]]
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3-SNAPSHOT"
+version in ThisBuild := "1.1.0-SNAPSHOT"


### PR DESCRIPTION
Core no longer has a cats-effect dependency.
The cats module defines all the typeclass instances, which can be imported
using `import com.comcast.ip4s.Implicits._`

The hostname resolution functionality has been moved into a separate
`HostnameResolver` object.

All tests pass.