### PR TITLE
Make IpAddress implemented Ordered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ target
 .metaserver
 .bloop
 .metals
+project/metals.sbt

--- a/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
@@ -16,7 +16,6 @@
 
 package com.comcast.ip4s
 
-import scala.math.Ordering.Implicits._
 import scala.util.Try
 import scala.util.hashing.MurmurHash3
 


### PR DESCRIPTION
We still need the implicit `Ordering` instance in the companion or else the other derived orderings will fail (due to https://github.com/scala/bug/issues/8541).