### PR TITLE
Fix Ipv6Address#toInetAddress when called on an IPv4-mapped address

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import sbtcrossproject.CrossPlugin.autoImport.CrossType
+import com.typesafe.tools.mima.core._
 
 ThisBuild / baseVersion := "3.0"
 
@@ -43,6 +44,10 @@ ThisBuild / scalafmtOnCompile := true
 ThisBuild / initialCommands := "import com.comcast.ip4s._"
 
 ThisBuild / fatalWarningsInCI := false
+
+ThisBuild / mimaBinaryIssueFilters ++= Seq(
+  ProblemFilters.exclude[DirectMissingMethodProblem]("com.comcast.ip4s.Ipv6Address.toInetAddress")
+)
 
 lazy val root = project
   .in(file("."))

--- a/jvm/src/main/scala/com/comcast/ip4s/IpAddressPlatform.scala
+++ b/jvm/src/main/scala/com/comcast/ip4s/IpAddressPlatform.scala
@@ -52,8 +52,8 @@ private[ip4s] trait Ipv4AddressCompanionPlatform {
 private[ip4s] trait Ipv6AddressPlatform extends IpAddressPlatform {
   protected val bytes: Array[Byte]
 
-  override def toInetAddress: Inet6Address =
-    InetAddress.getByAddress(bytes).asInstanceOf[Inet6Address]
+  override def toInetAddress: InetAddress =
+    InetAddress.getByAddress(bytes)
 }
 
 private[ip4s] trait Ipv6AddressCompanionPlatform {

--- a/test-kit/jvm/src/test/scala/com/comcast/ip4s/Ipv6AddressJvmTest.scala
+++ b/test-kit/jvm/src/test/scala/com/comcast/ip4s/Ipv6AddressJvmTest.scala
@@ -52,4 +52,8 @@ class Ipv6AddressJvmTest extends BaseTestSuite {
   test("support conversion to Inet6Address") {
     forAll { (ip: Ipv6Address) => assert(ip.toInetAddress.isInstanceOf[Inet6Address]) }
   }
+
+  test("toInetAddress with IPv4 mapped addresses") {
+    assertEquals(ip"::ffff:f:f".toInetAddress, InetAddress.getByName("::ffff:f:f"))
+  }
 }


### PR DESCRIPTION
Fixes #274 

This is a binary incompatible change, though only if you explicitly call `toInetAddress` on an `Ipv6Address` object. Most usage to `toInetAddress` will be on an `IpAddress` object, which remains compatible.