### PR TITLE
Make `Dns` cross-platform, add `reverse` methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,9 @@ lazy val testKit = crossProject(JVMPlatform, JSPlatform)
   .settings(
     libraryDependencies ++= Seq(
       "org.scalacheck" %%% "scalacheck" % "1.15.4",
-      "org.scalameta" %%% "munit-scalacheck" % "0.7.29" % Test
+      "org.scalameta" %%% "munit-scalacheck" % "0.7.29" % Test,
+      "org.typelevel" %%% "cats-effect" % "3.2.9" % Test,
+      "org.typelevel" %%% "munit-cats-effect-3" % "1.0.6" % Test,
     )
   )
   .jvmSettings(
@@ -108,15 +110,10 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
     }
   )
   .settings(
-    libraryDependencies += "org.typelevel" %%% "literally" % "1.0.2"
-  )
-  .jvmSettings(
-    libraryDependencies += "org.typelevel" %%% "cats-effect" % "3.2.9"
-  )
-  .settings(
     libraryDependencies ++= Seq(
+      "org.typelevel" %%% "literally" % "1.0.2",
       "org.typelevel" %%% "cats-core" % "2.6.1",
-      "org.scalacheck" %%% "scalacheck" % "1.15.4" % Test
+      "org.typelevel" %%% "cats-effect-kernel" % "3.2.9",
     )
   )
 

--- a/js/src/main/scala/com/comcast/ip4s/DnsPlatform.scala
+++ b/js/src/main/scala/com/comcast/ip4s/DnsPlatform.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+
+import cats.effect.kernel.Async
+import cats.syntax.all._
+
+import scala.scalajs.js
+import scala.scalajs.js.|
+import scala.scalajs.js.annotation.JSImport
+
+trait DnsCompanionPlatform {
+  implicit def forAsync[F[_]](implicit F: Async[F]): Dns[F] = new UnsealedDns[F] {
+    def resolve(hostname: Hostname): F[IpAddress] =
+      F.fromPromise(F.delay(dnsPromises.lookup(hostname.toString, LookupOptions(all = false))))
+        .flatMap { address =>
+          IpAddress
+            .fromString(address.asInstanceOf[LookupResult].address)
+            .liftTo[F](new RuntimeException("Node.js returned invalid IP address"))
+        }
+        .adaptError {
+          case ex @ js.JavaScriptException(error: js.Error) if error.message.contains("ENOTFOUND") =>
+            new JavaScriptUnknownHostException(hostname.toString, ex)
+        }
+
+    def resolveOption(hostname: Hostname): F[Option[IpAddress]] =
+      resolve(hostname).map(_.some).recover { case _: UnknownHostException => None }
+
+    def resolveAll(hostname: Hostname): F[List[IpAddress]] =
+      F.fromPromise(F.delay(dnsPromises.lookup(hostname.toString, LookupOptions(all = true))))
+        .flatMap { addresses =>
+          addresses
+            .asInstanceOf[js.Array[LookupResult]]
+            .toList
+            .traverse { address =>
+              IpAddress
+                .fromString(address.address)
+                .liftTo[F](new RuntimeException("Node.js returned invalid IP address"))
+            }
+        }
+        .recover {
+          case js.JavaScriptException(error: js.Error) if error.message.contains("ENOTFOUND") =>
+            Nil
+        }
+
+    def reverse(address: IpAddress): F[Hostname] =
+      reverseAllOrError(address).flatMap(_.headOption.liftTo(new UnknownHostException(address.toString)))
+
+    def reverseOption(address: IpAddress): F[Option[Hostname]] = reverseAll(address).map(_.headOption)
+
+    def reverseAll(address: IpAddress): F[List[Hostname]] =
+      reverseAllOrError(address).recover { case _: UnknownHostException => Nil }
+
+    private def reverseAllOrError(address: IpAddress): F[List[Hostname]] =
+      F.fromPromise(F.delay(dnsPromises.reverse(address.toString)))
+        .flatMap { hostnames =>
+          hostnames.toList.traverse { hostname =>
+            Hostname
+              .fromString(hostname)
+              .liftTo[F](new RuntimeException("Node.js returned invalid hostname"))
+          }
+        }
+        .adaptError {
+          case ex @ js.JavaScriptException(error: js.Error) if error.message.contains("ENOTFOUND") =>
+            new JavaScriptUnknownHostException(address.toString, ex)
+        }
+
+    def loopback: F[IpAddress] = resolve(Hostname.fromString("localhost").get)
+  }
+}
+
+@js.native
+@JSImport("dns", "promises")
+private[ip4s] object dnsPromises extends js.Any {
+
+  def lookup(hostname: String, options: LookupOptions): js.Promise[LookupResult | js.Array[LookupResult]] = js.native
+
+  def reverse(ip: String): js.Promise[js.Array[String]] = js.native
+}
+
+private[ip4s] sealed trait LookupOptions extends js.Object
+object LookupOptions {
+  def apply(all: Boolean): LookupOptions = js.Dynamic.literal(all = all).asInstanceOf[LookupOptions]
+}
+
+@js.native
+private[ip4s] sealed trait LookupResult extends js.Object {
+  def address: String = js.native
+  def family: Int = js.native
+}

--- a/js/src/main/scala/com/comcast/ip4s/UnknownHostException.scala
+++ b/js/src/main/scala/com/comcast/ip4s/UnknownHostException.scala
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
-package com.comcast
+package com.comcast.ip4s
 
-package object ip4s extends ip4splatform
+import java.io.IOException
+import scala.scalajs.js
+import scala.util.control.NoStackTrace
+
+class UnknownHostException(message: String = null, cause: Throwable = null) extends IOException(message, cause)
+
+private[ip4s] class JavaScriptUnknownHostException(message: String, cause: js.JavaScriptException)
+    extends UnknownHostException(message, cause)
+    with NoStackTrace

--- a/js/src/main/scala/com/comcast/ip4s/ip4splatform.scala
+++ b/js/src/main/scala/com/comcast/ip4s/ip4splatform.scala
@@ -16,4 +16,4 @@
 
 package com.comcast
 
-package object ip4s extends ip4splatform
+private[comcast] trait ip4splatform

--- a/jvm/src/main/scala/com/comcast/ip4s/ip4splatform.scala
+++ b/jvm/src/main/scala/com/comcast/ip4s/ip4splatform.scala
@@ -16,4 +16,6 @@
 
 package com.comcast
 
-package object ip4s extends ip4splatform
+private[comcast] trait ip4splatform {
+  type UnknownHostException = java.net.UnknownHostException
+}

--- a/shared/src/main/scala-2/package.scala
+++ b/shared/src/main/scala-2/package.scala
@@ -16,7 +16,7 @@
 
 package com.comcast
 
-package object ip4s {
+package object ip4s extends ip4splatform {
   final implicit class IpLiteralSyntax(val sc: StringContext) extends AnyVal {
     def ip(args: Any*): IpAddress = macro Literals.ip.make
     def ipv4(args: Any*): Ipv4Address =

--- a/shared/src/main/scala/com/comcast/ip4s/Dns.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Dns.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+
+/** Capability for an effect `F[_]` which can do DNS lookups.
+  *
+  * An instance is available for any effect which has a `Sync` instance on JVM and `Async` on Node.js.
+  */
+sealed trait Dns[F[_]] {
+
+  /** Resolves the supplied hostname to an ip address using the platform DNS resolver.
+    *
+    * If the hostname cannot be resolved, the effect fails with an `UnknownHostException`.
+    */
+  def resolve(hostname: Hostname): F[IpAddress]
+
+  /** Resolves the supplied hostname to an ip address using the platform DNS resolver.
+    *
+    * If the hostname cannot be resolved, a `None` is returned.
+    */
+  def resolveOption(hostname: Hostname): F[Option[IpAddress]]
+
+  /** Resolves the supplied hostname to all ip addresses known to the platform DNS resolver.
+    *
+    * If the hostname cannot be resolved, an empty list is returned.
+    */
+  def resolveAll(hostname: Hostname): F[List[IpAddress]]
+
+  /** Reverses the supplied address to a hostname using the platform DNS resolver.
+    *
+    * If the address cannot be reversed, the effect fails with an `UnknownHostException`.
+    */
+  def reverse(address: IpAddress): F[Hostname]
+
+  /** Reverses the supplied address to a hostname using the platform DNS resolver.
+    *
+    * If the address cannot be resolved, a `None` is returned.
+    */
+  def reverseOption(address: IpAddress): F[Option[Hostname]]
+
+  /** Reverses the supplied address to all hostnames known to the platform DNS resolver.
+    *
+    * If the address cannot be resolved, an empty list is returned.
+    */
+  def reverseAll(address: IpAddress): F[List[Hostname]]
+
+  /** Gets an IP address representing the loopback interface. */
+  def loopback: F[IpAddress]
+}
+
+private[ip4s] trait UnsealedDns[F[_]] extends Dns[F]
+
+object Dns extends DnsCompanionPlatform {
+  def apply[F[_]](implicit F: Dns[F]): F.type = F
+}

--- a/test-kit/shared/src/test/scala/com/comcast/ip4s/DnsTest.scala
+++ b/test-kit/shared/src/test/scala/com/comcast/ip4s/DnsTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+
+import cats.effect.IO
+import cats.syntax.all._
+import munit.CatsEffectSuite
+
+class DnsTest extends CatsEffectSuite {
+
+  test("resolve/reverseAll round-trip") {
+    for {
+      hostname <- Hostname.fromString("comcast.com").liftTo[IO](new NoSuchElementException)
+      address <- Dns[IO].resolve(hostname)
+      hostnames <- Dns[IO].reverseAll(address)
+      _ <- IO(assert(hostnames.nonEmpty))
+      reversedAddress <- hostnames.traverse(Dns[IO].resolve)
+    } yield assert(reversedAddress.forall(_ == address))
+  }
+
+  test("resolveAll/reverse round-trip") {
+    for {
+      hostname <- Hostname.fromString("comcast.com").liftTo[IO](new NoSuchElementException)
+      addresses <- Dns[IO].resolveAll(hostname)
+      _ <- IO(assert(addresses.nonEmpty))
+      hostnames <- addresses.traverse(Dns[IO].reverse)
+      reversedAddresses <- hostnames.traverse(Dns[IO].resolve)
+    } yield assertEquals(Set(addresses), Set(reversedAddresses))
+  }
+
+  test("loopback") {
+    assertIO(Dns[IO].loopback.map(_.some), IpAddress.fromString("127.0.0.1"))
+  }
+
+}


### PR DESCRIPTION
1. Adds `cats-effect-kernel` as both a JVM/JS dependency (`cats-effect` proper was previously a JVM dep)
2. Makes `Dns` a sealed trait (assume this is ok?) and adds `reverse`, `reverseOption`, and `reverseAll` methods
3. Implements `Dns` for Node.js (as long as browsers don't use `Dns` they won't have problems)
4. Adds `DnsTest`