### PR TITLE
Make `Port.{MinValue, MaxValue}` constant defs

### DIFF
--- a/shared/src/main/scala/com/comcast/ip4s/Port.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Port.scala
@@ -39,8 +39,8 @@ final class Port private (val value: Int) extends Product with Serializable with
 }
 
 object Port {
-  val MinValue: Int = 0
-  val MaxValue: Int = 65535
+  final val MinValue = 0
+  final val MaxValue = 65535
 
   def fromInt(value: Int): Option[Port] =
     if (value >= MinValue && value <= MaxValue) Some(new Port(value)) else None


### PR DESCRIPTION
> A constant value definition is of the form
> ```scala
> final val x = e
> ```
> where `e` is a [constant expression](https://www.scala-lang.org/files/archive/spec/2.13/06-expressions.html#constant-expressions). The final modifier must be present and no type annotation may be given. References to the constant value `x` are themselves treated as constant expressions; in the generated code they are replaced by the definition's right-hand side `e`.

https://www.scala-lang.org/files/archive/spec/2.13/04-basic-declarations-and-definitions.html#value-declarations-and-definitions