### PR TITLE
Move `fromHostname` within `representable` guard

### DIFF
--- a/test-kit/shared/src/test/scala/com/comcast/ip4s/IDNTest.scala
+++ b/test-kit/shared/src/test/scala/com/comcast/ip4s/IDNTest.scala
@@ -23,9 +23,9 @@ class IDNTest extends BaseTestSuite {
 
   test("support any hostname") {
     forAll { (h: Hostname) =>
-      val i = IDN.fromHostname(h)
       val representable = h.labels.forall(l => !l.toString.toLowerCase.startsWith("xn--"))
       if (representable) {
+        val i = IDN.fromHostname(h)
         assertEquals(i.hostname, h)
         assertEquals(IDN.fromString(h.toString), Some(i))
       }


### PR DESCRIPTION
I think this fixes https://github.com/Comcast/ip4s/issues/454.