### PR TITLE
Implicit `Dns` for `IO` only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import com.typesafe.tools.mima.core._
 
-ThisBuild / tlBaseVersion := "3.2"
+ThisBuild / tlBaseVersion := "3.3"
 
 ThisBuild / organization := "com.comcast"
 ThisBuild / organizationName := "Comcast Cable Communications Management, LLC"
@@ -46,7 +46,6 @@ lazy val testKit = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     libraryDependencies ++= Seq(
       "org.scalacheck" %%% "scalacheck" % "1.17.0",
       "org.scalameta" %%% "munit-scalacheck" % "1.0.0-M7" % Test,
-      "org.typelevel" %%% "cats-effect" % "3.4.8" % Test,
       "org.typelevel" %%% "munit-cats-effect" % "2.0.0-M3" % Test
     )
   )
@@ -78,7 +77,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "literally" % "1.1.0",
       "org.typelevel" %%% "cats-core" % "2.9.0",
-      "org.typelevel" %%% "cats-effect-kernel" % "3.4.8",
+      "org.typelevel" %%% "cats-effect" % "3.4.8",
       "org.scalacheck" %%% "scalacheck" % "1.17.0" % Test
     )
   )

--- a/js/src/main/scala/com/comcast/ip4s/DnsPlatform.scala
+++ b/js/src/main/scala/com/comcast/ip4s/DnsPlatform.scala
@@ -24,7 +24,7 @@ import scala.scalajs.js.|
 import scala.scalajs.js.annotation.JSImport
 
 private[ip4s] trait DnsCompanionPlatform {
-  implicit def forAsync[F[_]](implicit F: Async[F]): Dns[F] = new UnsealedDns[F] {
+  def forAsync[F[_]](implicit F: Async[F]): Dns[F] = new UnsealedDns[F] {
     def resolve(hostname: Hostname): F[IpAddress] =
       F.fromPromise(F.delay(dnsPromises.lookup(hostname.toString, LookupOptions(all = false))))
         .flatMap { address =>

--- a/jvm-native/src/main/scala/com/comcast/ip4s/DnsPlatform.scala
+++ b/jvm-native/src/main/scala/com/comcast/ip4s/DnsPlatform.scala
@@ -16,13 +16,16 @@
 
 package com.comcast.ip4s
 
+import cats.effect.kernel.Async
 import cats.effect.kernel.Sync
 import cats.syntax.all._
 
 import java.net.InetAddress
 
 private[ip4s] trait DnsCompanionPlatform {
-  implicit def forSync[F[_]](implicit F: Sync[F]): Dns[F] = new UnsealedDns[F] {
+  def forAsync[F[_]: Async]: Dns[F] = forSync // alias for cross-compiling w/ JS
+
+  def forSync[F[_]](implicit F: Sync[F]): Dns[F] = new UnsealedDns[F] {
     def resolve(hostname: Hostname): F[IpAddress] =
       F.blocking {
         val addr = InetAddress.getByName(hostname.toString)

--- a/shared/src/main/scala/com/comcast/ip4s/Dns.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Dns.scala
@@ -16,6 +16,8 @@
 
 package com.comcast.ip4s
 
+import cats.effect.IO
+
 /** Capability for an effect `F[_]` which can do DNS lookups.
   *
   * An instance is available for any effect which has a `Sync` instance on JVM and `Async` on Node.js.
@@ -66,4 +68,6 @@ private[ip4s] trait UnsealedDns[F[_]] extends Dns[F]
 
 object Dns extends DnsCompanionPlatform {
   def apply[F[_]](implicit F: Dns[F]): F.type = F
+
+  implicit def forIO: Dns[IO] = forAsync[IO]
 }


### PR DESCRIPTION
Discord thread: https://discord.com/channels/632277896739946517/839257183782436945/1087761519477014644

**tl;dr**: The motivation for removing the implicit implementation for generic `F[_]` is to force tagless final libs to declare _all_ of their constraints (e.g. `Dns`) instead of deriving them on-the-spot from e.g. `Async`. Meanwhile, this change will be completely transparent to code written in concrete `IO`.

Will follow-up with similar changes in FS2 for `Files`, `Network`, etc.