### PR TITLE
fixes for cidr equality, validity and consistency

### DIFF
--- a/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
@@ -37,6 +37,11 @@ sealed class Cidr[+A <: IpAddress] protected (val address: A, val prefixBits: In
     * is (and prints as) a spec-valid cidr range, with no bits outside the routing mask set.
     *
     * @return a normalized cidr range
+    *
+    * @example {{{
+    * scala> Cidr(ipv4"10.11.12.13", 8).normalized
+    * res0: Cidr.Strict[Ipv4Address] = 10.0.0.0/8
+    * }}}
     */
   def normalized: Strict[A] = Cidr.Strict(this)
 

--- a/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
@@ -138,7 +138,7 @@ object Cidr {
     * This means the address will never have any bits set outside the prefix. For example, a range
     * such as 192.168.0.1/31 is not allowed.
     */
-  final class Strict[+A <: IpAddress] private (override val prefix: A, override val prefixBits: Int)
+  final class Strict[+A <: IpAddress] private (override val prefix: A, prefixBits: Int)
       extends Cidr[A](prefix, prefixBits) {
     override def normalized: this.type = this
   }

--- a/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Cidr.scala
@@ -39,7 +39,9 @@ sealed class Cidr[+A <: IpAddress] protected (val address: A, val prefixBits: In
     * @return a normalized cidr range
     *
     * @example {{{
-    * scala> Cidr(ipv4"10.11.12.13", 8).normalized
+    * scala> val raw = Cidr(ipv4"10.11.12.13", 8)
+    * raw: Cidr[Ipv4Address] = 10.11.12.13/8
+    * scala> raw.normalized
     * res0: Cidr.Strict[Ipv4Address] = 10.0.0.0/8
     * }}}
     */

--- a/test-kit/shared/src/main/scala/com/comcast/ip4s/Arbitraries.scala
+++ b/test-kit/shared/src/main/scala/com/comcast/ip4s/Arbitraries.scala
@@ -45,6 +45,10 @@ object Arbitraries {
   implicit def cidrArbitrary[A <: IpAddress](implicit arbIp: Arbitrary[A]): Arbitrary[Cidr[A]] =
     Arbitrary(cidrGenerator(arbIp.arbitrary))
 
+  implicit def cidrStrictArbitrary[A <: IpAddress](implicit arbIp: Arbitrary[A]): Arbitrary[Cidr.Strict[A]] = Arbitrary(
+    cidrGenerator(arbIp.arbitrary).map(_.normalized)
+  )
+
   val portGenerator: Gen[Port] = Gen.chooseNum(0, 65535).map(Port.fromInt(_).get)
 
   implicit val portArbitrary: Arbitrary[Port] = Arbitrary(portGenerator)

--- a/test-kit/shared/src/test/scala/com/comcast/ip4s/CidrStrictTest.scala
+++ b/test-kit/shared/src/test/scala/com/comcast/ip4s/CidrStrictTest.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.comcast.ip4s
 
 import org.scalacheck.Prop.forAll

--- a/test-kit/shared/src/test/scala/com/comcast/ip4s/CidrStrictTest.scala
+++ b/test-kit/shared/src/test/scala/com/comcast/ip4s/CidrStrictTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Comcast Cable Communications Management, LLC
+ * Copyright 2018 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.comcast.ip4s
 
 import org.scalacheck.Prop.forAll

--- a/test-kit/shared/src/test/scala/com/comcast/ip4s/CidrStrictTest.scala
+++ b/test-kit/shared/src/test/scala/com/comcast/ip4s/CidrStrictTest.scala
@@ -1,0 +1,10 @@
+package com.comcast.ip4s
+
+import org.scalacheck.Prop.forAll
+import Arbitraries._
+
+class CidrStrictTest extends BaseTestSuite {
+  property("prefix and address are identical") {
+    forAll { (cidr: Cidr.Strict[IpAddress]) => assertEquals(cidr.address, cidr.prefix) }
+  }
+}


### PR DESCRIPTION
the root of the problem: 172.168.0.1/30 isn't a valid cidr range, because 172.168.0.1 isn't a valid prefix for a /30, but is accepted by both Cidr.fromString and Cidr.apply, which now cause cidr#toString to output invalid cidr ranges. 

This MR changes CIDR equality and printing:

equality: 
* before:  `ip"172.168.0.1" / 30 != ip"172.168.0.0" / 30`, even though it matches the same addressess
* after: `ip"172.168.0.1" / 30 == ip"172.168.0.0" / 30`, even though the base address is different

printing:
* before: `(ip"172.168.0.1" / 30).toString == "172.168.0.1/30"` even though that isn't a valid CIDR range
* after: `(ip"172.168.0.1" / 30).toString == "172.168.0.0/30"` even though that doesn't contain the base address

misc:
* `(adress0 / 0).address == adress0` still holds 
* `cidr1 == cidr2` no longer implies `cidr1.address == cidr2.address`
*  `cidr1 == cidr2` no longer implies `cidr1.productIterator.toList == cidr2.productIterator.toList`

This is not the only way to fix the given problems. The other obvious option is at construction (`Cidr.apply`) time, set address to prefix, and deprecate address for prefix. This is a bigger breaking change: it will break users that assume `(addr / 0).address == addr`. It also kills the (somewhat?) useful ability to have this datatype carry at the same time an arbitrary IP address and some cidr range the address is part of. passing around some machines ip / 24 (or something) does come up a fair bit in practice, and comes "for free" in the current implementation.

A third option is to provide separate between strict and lenient constructors


