### PR TITLE
Add UnixSocketAddress and GenSocketAddress, add Wildcard aliases for …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,9 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       if (tlIsScala3.value) Nil
       else List("org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided")
     },
-    scalacOptions := scalacOptions.value.filterNot(_ == "-source:3.0-migration")
+    scalacOptions := scalacOptions.value.filterNot(_ == "-source:3.0-migration"),
+    Compile / doc / scalacOptions ++= (if (scalaVersion.value.startsWith("2.")) Seq("-nowarn")
+                                       else Nil)
   )
   .settings(
     libraryDependencies ++= Seq(

--- a/shared/src/main/scala/com/comcast/ip4s/GenSocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/GenSocketAddress.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+
+/** Supertype for types that specify address information for opening a socket.
+  *
+  * There are two built-in subtypes:
+  *  - [[SocketAddress]] - which specifies address and port info for IPv4/IPv6 sockets
+  *  - [[UnixSocketAddress]] - which specifies the path to a unix domain socket
+  *
+  * This trait is left open for extension, allowing other address types to be defined.
+  * When using this trait, pattern match on the supported subtypes.
+  */
+trait GenSocketAddress

--- a/shared/src/main/scala/com/comcast/ip4s/GenSocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/GenSocketAddress.scala
@@ -25,4 +25,14 @@ package com.comcast.ip4s
   * This trait is left open for extension, allowing other address types to be defined.
   * When using this trait, pattern match on the supported subtypes.
   */
-abstract class GenSocketAddress private[ip4s] ()
+abstract class GenSocketAddress private[ip4s] () {
+
+  /** Downcasts this address to a `SocketAddress[IpAddress]`.
+   *
+   * @throws UnsupportedOperationException if this address is not a `SocketAddress[IpAddress]`
+   */
+  def asIpUnsafe: SocketAddress[IpAddress] = this match {
+    case addr @ SocketAddress(_: IpAddress, _) => addr.asInstanceOf[SocketAddress[IpAddress]]
+    case other => throw new UnsupportedOperationException(s"asIpUnsafe only supported on SocketAddress[IpAddress]: $other")
+  }
+}

--- a/shared/src/main/scala/com/comcast/ip4s/GenSocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/GenSocketAddress.scala
@@ -25,4 +25,4 @@ package com.comcast.ip4s
   * This trait is left open for extension, allowing other address types to be defined.
   * When using this trait, pattern match on the supported subtypes.
   */
-trait GenSocketAddress
+abstract class GenSocketAddress private[ip4s] ()

--- a/shared/src/main/scala/com/comcast/ip4s/GenSocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/GenSocketAddress.scala
@@ -28,11 +28,12 @@ package com.comcast.ip4s
 abstract class GenSocketAddress private[ip4s] () {
 
   /** Downcasts this address to a `SocketAddress[IpAddress]`.
-   *
-   * @throws UnsupportedOperationException if this address is not a `SocketAddress[IpAddress]`
-   */
+    *
+    * @throws UnsupportedOperationException if this address is not a `SocketAddress[IpAddress]`
+    */
   def asIpUnsafe: SocketAddress[IpAddress] = this match {
     case addr @ SocketAddress(_: IpAddress, _) => addr.asInstanceOf[SocketAddress[IpAddress]]
-    case other => throw new UnsupportedOperationException(s"asIpUnsafe only supported on SocketAddress[IpAddress]: $other")
+    case other =>
+      throw new UnsupportedOperationException(s"asIpUnsafe only supported on SocketAddress[IpAddress]: $other")
   }
 }

--- a/shared/src/main/scala/com/comcast/ip4s/Host.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Host.scala
@@ -196,6 +196,10 @@ sealed abstract class IpAddress extends IpAddressPlatform with Host with Seriali
   /** Maps a type-preserving function across this IP address. */
   def transform(v4: Ipv4Address => Ipv4Address, v6: Ipv6Address => Ipv6Address): this.type
 
+  /** Returns true if this address is either 0.0.0.0 or ::. */
+  def isWildcard: Boolean =
+    fold(_ == Ipv4Address.Wildcard, _ == Ipv6Address.Wildcard)
+
   /** Returns true if this address is in the multicast range. */
   def isMulticast: Boolean
 
@@ -424,6 +428,9 @@ final class Ipv4Address private (protected val bytes: Array[Byte]) extends IpAdd
 }
 
 object Ipv4Address extends Ipv4AddressCompanionPlatform {
+
+  /** Wildcard IPv4 address - 0.0.0.0 */
+  val Wildcard: Ipv4Address = fromBytes(0, 0, 0, 0)
 
   /** First IP address in the IPv4 multicast range. */
   val MulticastRangeStart: Ipv4Address = fromBytes(224, 0, 0, 0)
@@ -698,6 +705,10 @@ final class Ipv6Address private (protected val bytes: Array[Byte]) extends IpAdd
 }
 
 object Ipv6Address extends Ipv6AddressCompanionPlatform {
+
+  /** Wildcard IPv6 address - 0.0.0.0 */
+  val Wildcard: Ipv6Address =
+    fromBytes(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
   /** First IP address in the IPv6 multicast range. */
   val MulticastRangeStart: Ipv6Address =

--- a/shared/src/main/scala/com/comcast/ip4s/Port.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/Port.scala
@@ -42,6 +42,8 @@ object Port {
   final val MinValue = 0
   final val MaxValue = 65535
 
+  final val Wildcard: Port = new Port(0)
+
   def fromInt(value: Int): Option[Port] =
     if (value >= MinValue && value <= MaxValue) Some(new Port(value)) else None
 

--- a/shared/src/main/scala/com/comcast/ip4s/SocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/SocketAddress.scala
@@ -21,7 +21,7 @@ import cats.syntax.all._
 
 /** An IP address of the specified type and a port number. Used to describe the source or destination of a socket.
   */
-final case class SocketAddress[+A <: Host](host: A, port: Port) extends SocketAddressPlatform[A] with GenSocketAddress {
+final case class SocketAddress[+A <: Host](host: A, port: Port) extends GenSocketAddress with SocketAddressPlatform[A] {
   override def toString: String =
     host match {
       case _: Ipv6Address => s"[$host]:$port"

--- a/shared/src/main/scala/com/comcast/ip4s/SocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/SocketAddress.scala
@@ -21,7 +21,7 @@ import cats.syntax.all._
 
 /** An IP address of the specified type and a port number. Used to describe the source or destination of a socket.
   */
-final case class SocketAddress[+A <: Host](host: A, port: Port) extends SocketAddressPlatform[A] {
+final case class SocketAddress[+A <: Host](host: A, port: Port) extends SocketAddressPlatform[A] with GenSocketAddress {
   override def toString: String =
     host match {
       case _: Ipv6Address => s"[$host]:$port"
@@ -34,6 +34,10 @@ final case class SocketAddress[+A <: Host](host: A, port: Port) extends SocketAd
 }
 
 object SocketAddress extends SocketAddressCompanionPlatform {
+
+  /** Alias for 0.0.0.0:0. */
+  val Wildcard: SocketAddress[Host] = SocketAddress(Ipv4Address.Wildcard, Port.Wildcard)
+
   def fromString(value: String): Option[SocketAddress[Host]] =
     fromStringIp(value) orElse fromStringHostname(value) orElse fromStringIDN(value)
 

--- a/shared/src/main/scala/com/comcast/ip4s/SocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/SocketAddress.scala
@@ -38,6 +38,9 @@ object SocketAddress extends SocketAddressCompanionPlatform {
   /** Alias for 0.0.0.0:0. */
   val Wildcard: SocketAddress[Host] = SocketAddress(Ipv4Address.Wildcard, Port.Wildcard)
 
+  /** Alias for 0.0.0.0:port. */
+  def port(port: Port): SocketAddress[Host] = SocketAddress(Ipv4Address.Wildcard, port)
+
   def fromString(value: String): Option[SocketAddress[Host]] =
     fromStringIp(value) orElse fromStringHostname(value) orElse fromStringIDN(value)
 

--- a/shared/src/main/scala/com/comcast/ip4s/UnixSocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/UnixSocketAddress.scala
@@ -24,10 +24,6 @@ final case class UnixSocketAddress(path: String) extends GenSocketAddress with O
 }
 
 object UnixSocketAddress {
-
-  /** Alias for the address with an empty path. */
-  final val Wildcard: UnixSocketAddress = UnixSocketAddress("")
-
   implicit val order: Order[UnixSocketAddress] = Order.fromComparable[UnixSocketAddress]
   implicit val show: Show[UnixSocketAddress] = Show.fromToString[UnixSocketAddress]
 }

--- a/shared/src/main/scala/com/comcast/ip4s/UnixSocketAddress.scala
+++ b/shared/src/main/scala/com/comcast/ip4s/UnixSocketAddress.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.comcast.ip4s
+
+import cats.{Order, Show}
+
+final case class UnixSocketAddress(path: String) extends GenSocketAddress with Ordered[UnixSocketAddress] {
+  override def toString: String = path
+  override def compare(that: UnixSocketAddress): Int = path.compare(that.path)
+}
+
+object UnixSocketAddress {
+
+  /** Alias for the address with an empty path. */
+  final val Wildcard: UnixSocketAddress = UnixSocketAddress("")
+
+  implicit val order: Order[UnixSocketAddress] = Order.fromComparable[UnixSocketAddress]
+  implicit val show: Show[UnixSocketAddress] = Show.fromToString[UnixSocketAddress]
+}


### PR DESCRIPTION
…hosts and socket addresses

To be used in FS2 along the lines of:

```scala
trait Network[F[_]] {

  def client(address: GenSocketAddress, options: List[SocketOption] = Nil): Resource[F, Socket[F]] =
    address match {
      case sa: SocketAddress[h] => // open ip socket w/ sa.host and sa.port
      case u: UnixSocketAddress => // open unix socket with u.path
      case other => // raise unsupported address type exception
    }
}

// Bind socket on port 80 on all interfaces
Network[F].server(SocketAddress(IpAddress.Wildcard, port"80")).flatMap(...)

// Another way to do the same
Network[F].server(SocketAddress.port(port"80")).flatMap(...)

// Bind arbitrary socket on all interfaces
Network[F].server(SocketAddress.Wildcard).flatMap(...)

// Bind arbitrary socket on specific interface
Network[F].server(SocketAddress(ip"127.0.0.1", Port.Wildcard)).flatMap(...)
```

Resolves #466